### PR TITLE
Fix error when there are spaces in response body

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -169,7 +169,7 @@
 	echo '❌ $SLACK_TOKEN and $SLACK_CHANNEL are required.'
 fi
 res=$(curl -s -XPOST -d "token=$SLACK_TOKEN" -d "channel=$SLACK_CHANNEL" -d "text={query}" -d 'as_user=true' 'https://slack.com/api/chat.postMessage')
-if [ $(echo $res | grep '"ok":true') ]; then
+if echo $res | grep -q '"ok":true'; then
     echo "✅ Succeeded in posting {query}";
 else
     echo "❌ Failed to post {query}";


### PR DESCRIPTION
The notification script is not working when there is spaces in the response body(e.g. slack app name).

## Current behavior
```bash
#!/bin/bash

res=$1

if [ $(echo $res | grep '"ok":true') ]; then
    echo "✅ Succeeded in posting {query}";
else
    echo "❌ Failed to post {query}";
    echo $res >&2
fi
```

```
$ ./example.sh '{"ok":true,"name":"test app"}'
./example.sh: line 5: [: {"ok":true,"name":"test: unary operator expected
❌ Failed to post {query}
{"ok":true,"name":"test app"}
```

## After this patch
```bash
#!/bin/bash

res=$1

if echo $res | grep -q '"ok":true'; then
    echo "✅ Succeeded in posting {query}";
else
    echo "❌ Failed to post {query}";
    echo $res >&2
fi
```

```
$ ./example.sh '{"ok":true,"name":"test app"}'
✅ Succeeded in posting {query}

$ ./example.sh '{"ok":false,"name":"test app"}'
❌ Failed to post {query}
{"ok":false,"name":"test app"}
```